### PR TITLE
Correct vpc property in eip resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "aws_transfer_ssh_key" "default" {
 resource "aws_eip" "sftp" {
   count = local.enabled && var.eip_enabled ? length(var.subnet_ids) : 0
 
-  vpc = local.is_vpc
+  domain = local.is_vpc
 
   tags = module.this.tags
 }


### PR DESCRIPTION
FIX: Correct eip resource property

- Change vpc to domain.
